### PR TITLE
Chapter/01/statement 커스텀

### DIFF
--- a/01/createPerformanceCalculator.test.ts
+++ b/01/createPerformanceCalculator.test.ts
@@ -1,0 +1,22 @@
+import createPerformanceCalculator from './createPerformanceCalculator';
+import { Plays } from './interface';
+import invoices from './invoices.json';
+import plays from './plays.json';
+
+const calculators = invoices[0].performances.map((performance) => {
+  const play = (plays as Plays)[performance.playID];
+
+  return createPerformanceCalculator(performance, play);
+});
+
+test('연극 별 비용 책정', () => {
+  calculators.forEach((calculator) => {
+    expect(calculator.amount).toBeGreaterThan(-1);
+  });
+});
+
+test('연극 별 포인트 책정', () => {
+  calculators.forEach((calculator) => {
+    expect(calculator.volumeCredits).toBeGreaterThan(-1);
+  });
+});

--- a/01/createPerformanceCalculator.ts
+++ b/01/createPerformanceCalculator.ts
@@ -1,0 +1,57 @@
+import { Performance, PerformanceCalculator, Play } from './interface';
+
+function getVolumeCredits(
+  calculator: PerformanceCalculator,
+  performance: Performance
+) {
+  const volumeCredits = Math.max(performance.audience - 30, 0);
+
+  if (calculator instanceof ComedyCalculator) {
+    return volumeCredits + Math.floor(performance.audience / 5);
+  }
+
+  return volumeCredits;
+}
+
+class TragedyCalculator implements PerformanceCalculator {
+  get amount() {
+    let result = 40000;
+    if (this.performance.audience > 30) {
+      result += 1000 * (this.performance.audience - 30);
+    }
+    return result;
+  }
+
+  volumeCredits = getVolumeCredits(this, this.performance);
+
+  constructor(private performance: Performance) {}
+}
+
+class ComedyCalculator implements PerformanceCalculator {
+  get amount() {
+    let result = 30000;
+    if (this.performance.audience > 20) {
+      result += 10000 + 500 * (this.performance.audience - 20);
+    }
+    result += 300 * this.performance.audience;
+    return result;
+  }
+
+  volumeCredits = getVolumeCredits(this, this.performance);
+
+  constructor(private performance: Performance) {}
+}
+
+export default function createPerformanceCalculator(
+  aPerformance: Performance,
+  aPlay: Play
+) {
+  switch (aPlay.type) {
+    case 'tragedy':
+      return new TragedyCalculator(aPerformance);
+    case 'comedy':
+      return new ComedyCalculator(aPerformance);
+    default:
+      throw new Error(`알 수 없는 장르: ${this.play.type}`);
+  }
+}

--- a/01/createStatemantData.test.ts
+++ b/01/createStatemantData.test.ts
@@ -1,6 +1,6 @@
-const createStatemantData = require('./createStatemantData');
-const plays = require('./plays.json');
-const invoices = require('./invoices.json');
+import createStatemantData from './createStatemantData';
+import invoices from './invoices.json';
+import plays from './plays.json';
 
 test('연극 비용 책정', () => {
   expect(createStatemantData(invoices[0], plays)).toEqual({

--- a/01/createStatemantData.test.ts
+++ b/01/createStatemantData.test.ts
@@ -1,9 +1,10 @@
 import createStatemantData from './createStatemantData';
+import { Plays } from './interface';
 import invoices from './invoices.json';
 import plays from './plays.json';
 
 test('연극 비용 책정', () => {
-  expect(createStatemantData(invoices[0], plays)).toEqual({
+  expect(createStatemantData(invoices[0], plays as Plays)).toEqual({
     customer: 'BigCo',
     performances: [
       {

--- a/01/createStatemantData.ts
+++ b/01/createStatemantData.ts
@@ -2,6 +2,7 @@ import {
   EnrichPerformance,
   Invoice,
   Performance,
+  PerformanceCalculator,
   Play,
   Plays,
   Statement,
@@ -20,15 +21,7 @@ function getVolumeCredits(
   return volumeCredits;
 }
 
-class PerformanceCalculator {
-  get amount(): number | void {
-    throw new Error('서브클래스에서 처리하도록 설계되었습니다.');
-  }
-
-  constructor(protected performance: Performance) {}
-}
-
-class TragedyCalculator extends PerformanceCalculator {
+class TragedyCalculator implements PerformanceCalculator {
   get amount() {
     let result = 40000;
     if (this.performance.audience > 30) {
@@ -38,9 +31,11 @@ class TragedyCalculator extends PerformanceCalculator {
   }
 
   volumeCredits = getVolumeCredits(this, this.performance);
+
+  constructor(private performance: Performance) {}
 }
 
-class ComedyCalculator extends PerformanceCalculator {
+class ComedyCalculator implements PerformanceCalculator {
   get amount() {
     let result = 30000;
     if (this.performance.audience > 20) {
@@ -51,6 +46,8 @@ class ComedyCalculator extends PerformanceCalculator {
   }
 
   volumeCredits = getVolumeCredits(this, this.performance);
+
+  constructor(private performance: Performance) {}
 }
 
 function createPerformanceCalculator(aPerformance: Performance, aPlay: Play) {

--- a/01/createStatemantData.ts
+++ b/01/createStatemantData.ts
@@ -7,13 +7,22 @@ import {
   Statement,
 } from './interface';
 
+function getVolumeCredits(
+  calculator: PerformanceCalculator,
+  performance: Performance
+) {
+  const volumeCredits = Math.max(performance.audience - 30, 0);
+
+  if (calculator instanceof ComedyCalculator) {
+    return volumeCredits + Math.floor(performance.audience / 5);
+  }
+
+  return volumeCredits;
+}
+
 class PerformanceCalculator {
   get amount(): number | void {
     throw new Error('서브클래스에서 처리하도록 설계되었습니다.');
-  }
-
-  get volumeCredits() {
-    return Math.max(this.performance.audience - 30, 0);
   }
 
   constructor(protected performance: Performance) {}
@@ -27,6 +36,8 @@ class TragedyCalculator extends PerformanceCalculator {
     }
     return result;
   }
+
+  volumeCredits = getVolumeCredits(this, this.performance);
 }
 
 class ComedyCalculator extends PerformanceCalculator {
@@ -39,9 +50,7 @@ class ComedyCalculator extends PerformanceCalculator {
     return result;
   }
 
-  get volumeCredits() {
-    return super.volumeCredits + Math.floor(this.performance.audience / 5);
-  }
+  volumeCredits = getVolumeCredits(this, this.performance);
 }
 
 function createPerformanceCalculator(aPerformance: Performance, aPlay: Play) {

--- a/01/createStatemantData.ts
+++ b/01/createStatemantData.ts
@@ -1,65 +1,11 @@
+import createPerformanceCalculator from './createPerformanceCalculator';
 import {
   EnrichPerformance,
   Invoice,
   Performance,
-  PerformanceCalculator,
-  Play,
   Plays,
   Statement,
 } from './interface';
-
-function getVolumeCredits(
-  calculator: PerformanceCalculator,
-  performance: Performance
-) {
-  const volumeCredits = Math.max(performance.audience - 30, 0);
-
-  if (calculator instanceof ComedyCalculator) {
-    return volumeCredits + Math.floor(performance.audience / 5);
-  }
-
-  return volumeCredits;
-}
-
-class TragedyCalculator implements PerformanceCalculator {
-  get amount() {
-    let result = 40000;
-    if (this.performance.audience > 30) {
-      result += 1000 * (this.performance.audience - 30);
-    }
-    return result;
-  }
-
-  volumeCredits = getVolumeCredits(this, this.performance);
-
-  constructor(private performance: Performance) {}
-}
-
-class ComedyCalculator implements PerformanceCalculator {
-  get amount() {
-    let result = 30000;
-    if (this.performance.audience > 20) {
-      result += 10000 + 500 * (this.performance.audience - 20);
-    }
-    result += 300 * this.performance.audience;
-    return result;
-  }
-
-  volumeCredits = getVolumeCredits(this, this.performance);
-
-  constructor(private performance: Performance) {}
-}
-
-function createPerformanceCalculator(aPerformance: Performance, aPlay: Play) {
-  switch (aPlay.type) {
-    case 'tragedy':
-      return new TragedyCalculator(aPerformance);
-    case 'comedy':
-      return new ComedyCalculator(aPerformance);
-    default:
-      throw new Error(`알 수 없는 장르: ${this.play.type}`);
-  }
-}
 
 export default function createStatementData(
   invoice: Invoice,

--- a/01/createStatemantData.ts
+++ b/01/createStatemantData.ts
@@ -50,16 +50,18 @@ export default function createStatementData(invoice, plays) {
   const statementData: any = {}; // FIXME: any
   statementData.customer = invoice.customer;
   statementData.performances = invoice.performances.map(enrichPerformance);
-  statementData.totalAmount = totalAmount(statementData);
-  statementData.totalVolumeCredits = totalVolumeCredits(statementData);
+  statementData.totalAmount = totalAmount(statementData.performances);
+  statementData.totalVolumeCredits = totalVolumeCredits(
+    statementData.performances
+  );
   return statementData;
 
-  function totalAmount(data) {
-    return data.performances.reduce((total, p) => total + p.amount, 0);
+  function totalAmount(performances) {
+    return performances.reduce((total, p) => total + p.amount, 0);
   }
 
-  function totalVolumeCredits(data) {
-    return data.performances.reduce((total, p) => total + p.volumeCredits, 0);
+  function totalVolumeCredits(performances) {
+    return performances.reduce((total, p) => total + p.volumeCredits, 0);
   }
 
   function enrichPerformance(aPerformance) {

--- a/01/createStatemantData.ts
+++ b/01/createStatemantData.ts
@@ -1,5 +1,5 @@
 class PerformanceCalculator {
-  get amount() {
+  get amount(): number | void {
     throw new Error('서브클래스에서 처리하도록 설계되었습니다.');
   }
 
@@ -7,10 +7,7 @@ class PerformanceCalculator {
     return Math.max(this.performance.audience - 30, 0);
   }
 
-  constructor(aPerformance, aPlay) {
-    this.performance = aPerformance;
-    this.play = aPlay;
-  }
+  constructor(public performance, public play) {}
 }
 
 class TragedyCalculator extends PerformanceCalculator {
@@ -49,8 +46,8 @@ function createPerformanceCalculator(aPerformance, aPlay) {
   }
 }
 
-function createStatementData(invoice, plays) {
-  const statementData = {};
+export default function createStatementData(invoice, plays) {
+  const statementData: any = {}; // FIXME: any
   statementData.customer = invoice.customer;
   statementData.performances = invoice.performances.map(enrichPerformance);
   statementData.totalAmount = totalAmount(statementData);
@@ -81,5 +78,3 @@ function createStatementData(invoice, plays) {
     return plays[aPerformance.playID];
   }
 }
-
-module.exports = createStatementData;

--- a/01/createStatemantData.ts
+++ b/01/createStatemantData.ts
@@ -16,7 +16,7 @@ class PerformanceCalculator {
     return Math.max(this.performance.audience - 30, 0);
   }
 
-  constructor(protected performance: Performance, public play: Play) {}
+  constructor(protected performance: Performance) {}
 }
 
 class TragedyCalculator extends PerformanceCalculator {
@@ -47,9 +47,9 @@ class ComedyCalculator extends PerformanceCalculator {
 function createPerformanceCalculator(aPerformance: Performance, aPlay: Play) {
   switch (aPlay.type) {
     case 'tragedy':
-      return new TragedyCalculator(aPerformance, aPlay);
+      return new TragedyCalculator(aPerformance);
     case 'comedy':
-      return new ComedyCalculator(aPerformance, aPlay);
+      return new ComedyCalculator(aPerformance);
     default:
       throw new Error(`알 수 없는 장르: ${this.play.type}`);
   }
@@ -76,14 +76,12 @@ export default function createStatementData(
   }
 
   function enrichPerformance(aPerformance: Performance): EnrichPerformance {
-    const calculator = createPerformanceCalculator(
-      aPerformance,
-      playFor(aPerformance)
-    );
+    const play = playFor(aPerformance);
+    const calculator = createPerformanceCalculator(aPerformance, play);
 
     return {
       ...aPerformance,
-      play: calculator.play,
+      play,
       amount: calculator.amount,
       volumeCredits: calculator.volumeCredits,
     };

--- a/01/interface.ts
+++ b/01/interface.ts
@@ -3,10 +3,13 @@ export interface Performance {
   audience: number;
 }
 
-export interface EnrichPerformance extends Performance {
-  play: Play;
+export interface PerformanceCalculator {
   amount: number;
   volumeCredits: number;
+}
+
+export interface EnrichPerformance extends Performance, PerformanceCalculator {
+  play: Play;
 }
 
 export interface Play {

--- a/01/interface.ts
+++ b/01/interface.ts
@@ -1,15 +1,15 @@
-interface Performance {
+export interface Performance {
   playID: string;
   audience: number;
 }
 
-interface EnrichPerformance extends Performance {
+export interface EnrichPerformance extends Performance {
   play: Play;
   amount: number;
   volumeCredits: number;
 }
 
-interface Play {
+export interface Play {
   name: string;
   type: 'tragedy' | 'comedy';
 }

--- a/01/interface.ts
+++ b/01/interface.ts
@@ -1,0 +1,31 @@
+interface Performance {
+  playID: string;
+  audience: number;
+}
+
+interface EnrichPerformance extends Performance {
+  play: Play;
+  amount: number;
+  volumeCredits: number;
+}
+
+interface Play {
+  name: string;
+  type: 'tragedy' | 'comedy';
+}
+
+export interface Statement {
+  customer: string;
+  performances: Array<EnrichPerformance>;
+  totalAmount: number;
+  totalVolumeCredits: number;
+}
+
+export interface Plays {
+  [playID: string]: Play;
+}
+
+export interface Invoice {
+  customer: string;
+  performances: Array<Performance>;
+}

--- a/01/statement.test.ts
+++ b/01/statement.test.ts
@@ -1,15 +1,16 @@
+import { Plays } from './interface';
 import invoices from './invoices.json';
 import plays from './plays.json';
 import { htmlStatement, statement } from './statement';
 
 test('연극 비용 책정', () => {
-  expect(statement(invoices[0], plays)).toBe(
+  expect(statement(invoices[0], plays as Plays)).toBe(
     '청구 내역 (고객명: BigCo)\n  Hamlet: $650.00 (55석)\n  As Your Like It: $580.00 (35석)\n  Othello: $500.00 (40석)\n총액: $1,730.00\n적립 포인트: 47점\n'
   );
 });
 
 test('연극 비용 책정 HTML', () => {
-  expect(htmlStatement(invoices[0], plays)).toBe(
+  expect(htmlStatement(invoices[0], plays as Plays)).toBe(
     '<h1>청구 내역 (고객명: BigCo)</hi>\n<table>\n<tr><th>연극</th><th>좌석 수</th><th>금액</th></tr>\n  <tr><td>Hamlet</td><td>55</td><td>$650.00</td></tr>\n  <tr><td>As Your Like It</td><td>35</td><td>$580.00</td></tr>\n  <tr><td>Othello</td><td>40</td><td>$500.00</td></tr>\n</table>\n<p>총액: <em>$1,730.00</em></p>\n<p>적립 포인트: <em>$0.47</em>점</p>\n'
   );
 });

--- a/01/statement.test.ts
+++ b/01/statement.test.ts
@@ -1,6 +1,6 @@
-const { statement, htmlStatement } = require('./statement');
-const plays = require('./plays.json');
-const invoices = require('./invoices.json');
+import invoices from './invoices.json';
+import plays from './plays.json';
+import { htmlStatement, statement } from './statement';
 
 test('연극 비용 책정', () => {
   expect(statement(invoices[0], plays)).toBe(

--- a/01/statement.ts
+++ b/01/statement.ts
@@ -1,6 +1,6 @@
-const createStatementData = require('./createStatemantData');
+import createStatementData from './createStatemantData';
 
-function statement(invoice, plays) {
+export function statement(invoice, plays) {
   return renderPlainText(createStatementData(invoice, plays));
 }
 
@@ -14,7 +14,7 @@ function renderPlainText(data) {
   return result;
 }
 
-function htmlStatement(invoice, plays) {
+export function htmlStatement(invoice, plays) {
   return renderHtml(createStatementData(invoice, plays));
 }
 
@@ -40,8 +40,3 @@ function usd(aNumber) {
     minimumFractionDigits: 2,
   }).format(aNumber / 100);
 }
-
-module.exports = {
-  statement,
-  htmlStatement,
-};

--- a/01/statement.ts
+++ b/01/statement.ts
@@ -1,10 +1,11 @@
 import createStatementData from './createStatemantData';
+import { Invoice, Plays, Statement } from './interface';
 
-export function statement(invoice, plays) {
+export function statement(invoice: Invoice, plays: Plays) {
   return renderPlainText(createStatementData(invoice, plays));
 }
 
-function renderPlainText(data) {
+function renderPlainText(data: Statement) {
   let result = `청구 내역 (고객명: ${data.customer})\n`;
   for (let perf of data.performances) {
     result += `  ${perf.play.name}: ${usd(perf.amount)} (${perf.audience}석)\n`;
@@ -14,11 +15,11 @@ function renderPlainText(data) {
   return result;
 }
 
-export function htmlStatement(invoice, plays) {
+export function htmlStatement(invoice: Invoice, plays: Plays) {
   return renderHtml(createStatementData(invoice, plays));
 }
 
-function renderHtml(data) {
+function renderHtml(data: Statement) {
   let result = `<h1>청구 내역 (고객명: ${data.customer})</hi>\n`;
   result += `<table>\n`;
   result += '<tr><th>연극</th><th>좌석 수</th><th>금액</th></tr>\n';
@@ -33,7 +34,7 @@ function renderHtml(data) {
   return result;
 }
 
-function usd(aNumber) {
+function usd(aNumber: number) {
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "target": "ES6"
+    "target": "ES6",
+    "noImplicitAny": true
   }
 }


### PR DESCRIPTION
- 장르별 계산기 인스턴스가 이미 자신의 타입을 설명하고 있으므로`play` 속성 제거 (아울러 계산기에 연극 명 `play.name`은 필요없음. 계산기란 이름의 책임을 흐림) (https://github.com/rulewrite/refactoring-2nd-example/pull/2/commits/b30c4b62001ee1c9197f645ba59762e04e3107b2)
- 상속은 복잡도가 올라갈 수 있어(메소드 오버라이딩, 상속에 상속에 상속 등) 장르별 계산기들이 공통된 인터페이스를 구현하도록 변경 (덕타이핑) (https://github.com/rulewrite/refactoring-2nd-example/pull/2/commits/4bd850fee99cf71ebf9fb7e9fd6f4e12ee852c1d)